### PR TITLE
bump appeng version to 11.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## Unreleased
+
+### Changed
+- minimum required AE2 version is now 11.6.2
+
+### Fixed
+- recipe for in-world crafting of Resonating Dust not showing ([#29], [#30])
+- all mod recipes disappearing after a reload ([#28])
+
+<!-- Links -->
+[#28]: https://github.com/AlmostReliable/lazierae2-forge/issues/28
+[#29]: https://github.com/AlmostReliable/lazierae2-forge/issues/29
+[#30]: https://github.com/AlmostReliable/lazierae2-forge/issues/30
+
 ## [3.1.4] - 2022-10-14
 
 ### Removed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,7 +87,7 @@ dependencies {
         parchment("org.parchmentmc.data:$mappingsChannel-$mcVersion:$mappingsVersion@zip")
     })
 
-    modCompileOnly(modLocalRuntime("appeng:appliedenergistics2:$ae2Version")!!)
+    modCompileOnly(modLocalRuntime("appeng:appliedenergistics2-forge:$ae2Version")!!)
     modCompileOnly(modLocalRuntime("com.blamejared.crafttweaker:CraftTweaker-forge-$mcVersion:$crtVersion")!!)
     modCompileOnly(modLocalRuntime("dev.latvian.mods:kubejs-forge:$kubeVersion")!!)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,8 +29,8 @@ githubUser = AlmostReliable
 githubRepo = lazierae2-forge
 
 # Dependencies
-ae2Version = 11.4.0
-ae2VersionRange = [11.1.4,12.0)
+ae2Version = 11.7.0
+ae2VersionRange = [11.7.0,12.0)
 jeiVersion = 9.7.2.264
 jeiVersionRange = [9.7.2.259,11.0)
 crtVersion = 9.1.190

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ githubRepo = lazierae2-forge
 
 # Dependencies
 ae2Version = 11.7.0
-ae2VersionRange = [11.7.0,12.0)
+ae2VersionRange = [11.6.2,12.0)
 jeiVersion = 9.7.2.264
 jeiVersionRange = [9.7.2.259,11.0)
 crtVersion = 9.1.190

--- a/src/main/java/com/almostreliable/lazierae2/compat/jei/Plugin.java
+++ b/src/main/java/com/almostreliable/lazierae2/compat/jei/Plugin.java
@@ -24,7 +24,6 @@ import com.almostreliable.lazierae2.util.TextUtil;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.constants.VanillaTypes;
-import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.registration.*;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;

--- a/src/main/java/com/almostreliable/lazierae2/compat/jei/Plugin.java
+++ b/src/main/java/com/almostreliable/lazierae2/compat/jei/Plugin.java
@@ -95,7 +95,7 @@ public class Plugin implements IModPlugin {
             validateRecipes(rm.getAllRecipesFor(ProcessorType.INFUSER), TripleInputRecipe.class)
         );
 
-        var inWaterRecipes = new ArrayList<>();
+        var inWaterRecipes = new ArrayList<ThrowingInWaterDisplay>();
         if (AEConfig.instance().isInWorldCrystalGrowthEnabled()) {
             inWaterRecipes.add(new ThrowingInWaterDisplay(
                 List.of(Ingredient.of(Items.RESONATING_SEED.get())),
@@ -110,7 +110,7 @@ public class Plugin implements IModPlugin {
                 Ingredient.of(AEItems.ENDER_DUST)
             ), new ItemStack(Items.RESONATING_DUST.get(), 2), false));
         }
-        r.addRecipes(new RecipeType<>(ThrowingInWaterCategory.ID, ThrowingInWaterDisplay.class), inWaterRecipes);
+        r.addRecipes(ThrowingInWaterCategory.RECIPE_TYPE, inWaterRecipes);
 
         registerInfoPages(r);
     }


### PR DESCRIPTION
With https://github.com/AppliedEnergistics/Applied-Energistics-2/pull/6679 `ThrowingInWaterCategory.ID` was removed. Because of this the JEI Plugin crashes because of a `NoSuchFieldError`. 
This PR will use the new `ThrowingInWaterCategory.RECIPE_TYPE`